### PR TITLE
Fix test looker credentials

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -42,7 +42,12 @@ class Component extends BaseComponent
     public function __construct(LoggerInterface $logger)
     {
         parent::__construct($logger);
-        $this->dbBackend = $this->createBackendWrapper();
+
+        // "parameters.db.driver" is not provided in the config for testLookerCredentials,
+        // ... so we cannot create backend wrapper
+        if (in_array($this->getConfig()->getAction(), [self::ACTION_RUN, self::ACTION_TEST_CONNECTION])) {
+            $this->dbBackend = $this->createBackendWrapper();
+        }
     }
 
     protected function getSyncActions(): array


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-174

Zistil som, ze ako sa pridavala podpora pre BigQuery, tak prestali fungovat `testLookerCredentials`, ... kedze pri tejto synchronnej akcii nie je v configu pritomny `db.driver` (`snowflake`/`bigquery`) a teda nemozeme vytvorit backend wrapper (ktory pri tejto sync akcii netreba) ... ja som to testoval povodne cez API, a ked sa spravilo UI, tak som to uz neotestoval ... takze toto je potrebne fixnut skor ako sa pustim do COM-174.